### PR TITLE
Bug 41268: use variables rather than conditionals

### DIFF
--- a/admin/smart-rules.pl
+++ b/admin/smart-rules.pl
@@ -205,65 +205,19 @@ if ( $op eq 'cud-delete' ) {
     }
 } elsif ( $op eq 'cud-delete-branch-item' ) {
     my $itemtype = $input->param('itemtype');
-    if ( $branch eq "*" ) {
-        if ( $itemtype eq "*" ) {
-            Koha::CirculationRules->set_rules(
-                {
-                    branchcode => undef,
-                    itemtype   => undef,
-                    rules      => {
-                        holdallowed             => undef,
-                        hold_fulfillment_policy => undef,
-                        bookings_lead_period    => undef,
-                        bookings_trail_period   => undef,
-                        returnbranch            => undef,
-                    }
-                }
-            );
-        } else {
-            Koha::CirculationRules->set_rules(
-                {
-                    branchcode => undef,
-                    itemtype   => $itemtype,
-                    rules      => {
-                        holdallowed             => undef,
-                        hold_fulfillment_policy => undef,
-                        bookings_lead_period    => undef,
-                        bookings_trail_period   => undef,
-                        returnbranch            => undef,
-                    }
-                }
-            );
+    Koha::CirculationRules->set_rules(
+        {
+            branchcode => $branch eq '*'   ? undef : $branch,
+            itemtype   => $itemtype eq '*' ? undef : $itemtype,
+            rules      => {
+                holdallowed             => undef,
+                hold_fulfillment_policy => undef,
+                bookings_lead_period    => undef,
+                bookings_trail_period   => undef,
+                returnbranch            => undef,
+            }
         }
-    } elsif ( $itemtype eq "*" ) {
-        Koha::CirculationRules->set_rules(
-            {
-                branchcode => $branch,
-                itemtype   => undef,
-                rules      => {
-                    holdallowed             => undef,
-                    hold_fulfillment_policy => undef,
-                    bookings_lead_period    => undef,
-                    bookings_trail_period   => undef,
-                    returnbranch            => undef,
-                }
-            }
-        );
-    } else {
-        Koha::CirculationRules->set_rules(
-            {
-                branchcode => $branch,
-                itemtype   => $itemtype,
-                rules      => {
-                    holdallowed             => undef,
-                    hold_fulfillment_policy => undef,
-                    bookings_lead_period    => undef,
-                    bookings_trail_period   => undef,
-                    returnbranch            => undef,
-                }
-            }
-        );
-    }
+    );
 }
 
 # save the values entered
@@ -384,58 +338,34 @@ elsif ( $op eq 'cud-add' ) {
     my $returnbranch            = $input->param('returnbranch');
     my $max_holds               = strip_non_numeric( scalar $input->param('max_holds') );
 
-    if ( $branch eq "*" ) {
-        Koha::CirculationRules->set_rules(
-            {
-                itemtype   => undef,
-                branchcode => undef,
-                rules      => {
-                    holdallowed             => $holdallowed,
-                    hold_fulfillment_policy => $hold_fulfillment_policy,
-                    bookings_lead_period    => $bookings_lead_period,
-                    bookings_trail_period   => $bookings_trail_period,
-                    returnbranch            => $returnbranch,
-                }
+    my $branchcode = $branch eq '*' ? undef : $branch;
+
+    Koha::CirculationRules->set_rules(
+        {
+            itemtype   => undef,
+            branchcode => $branchcode,
+            rules      => {
+                holdallowed             => $holdallowed,
+                hold_fulfillment_policy => $hold_fulfillment_policy,
+                bookings_lead_period    => $bookings_lead_period,
+                bookings_trail_period   => $bookings_trail_period,
+                returnbranch            => $returnbranch,
             }
-        );
-        Koha::CirculationRules->set_rules(
-            {
-                categorycode => undef,
-                branchcode   => undef,
-                rules        => {
-                    patron_maxissueqty       => $patron_maxissueqty,
-                    patron_maxonsiteissueqty => $patron_maxonsiteissueqty,
-                }
+        }
+    );
+    Koha::CirculationRules->set_rules(
+        {
+            categorycode => undef,
+            branchcode   => $branchcode,
+            rules        => {
+                patron_maxissueqty       => $patron_maxissueqty,
+                patron_maxonsiteissueqty => $patron_maxonsiteissueqty,
             }
-        );
-    } else {
-        Koha::CirculationRules->set_rules(
-            {
-                itemtype   => undef,
-                branchcode => $branch,
-                rules      => {
-                    holdallowed             => $holdallowed,
-                    hold_fulfillment_policy => $hold_fulfillment_policy,
-                    bookings_lead_period    => $bookings_lead_period,
-                    bookings_trail_period   => $bookings_trail_period,
-                    returnbranch            => $returnbranch,
-                }
-            }
-        );
-        Koha::CirculationRules->set_rules(
-            {
-                categorycode => undef,
-                branchcode   => $branch,
-                rules        => {
-                    patron_maxissueqty       => $patron_maxissueqty,
-                    patron_maxonsiteissueqty => $patron_maxonsiteissueqty,
-                }
-            }
-        );
-    }
+        }
+    );
     Koha::CirculationRules->set_rule(
         {
-            branchcode   => $branch,
+            branchcode   => $branchcode,
             categorycode => undef,
             rule_name    => 'max_holds',
             rule_value   => $max_holds,
@@ -449,57 +379,17 @@ elsif ( $op eq 'cud-add' ) {
     my $max_holds = $input->param('max_holds');
     $max_holds = strip_non_numeric($max_holds);
 
-    if ( $branch eq "*" ) {
-        if ( $categorycode eq "*" ) {
-            Koha::CirculationRules->set_rules(
-                {
-                    categorycode => undef,
-                    branchcode   => undef,
-                    rules        => {
-                        max_holds                => $max_holds,
-                        patron_maxissueqty       => $patron_maxissueqty,
-                        patron_maxonsiteissueqty => $patron_maxonsiteissueqty,
-                    }
-                }
-            );
-        } else {
-            Koha::CirculationRules->set_rules(
-                {
-                    categorycode => $categorycode,
-                    branchcode   => undef,
-                    rules        => {
-                        max_holds                => $max_holds,
-                        patron_maxissueqty       => $patron_maxissueqty,
-                        patron_maxonsiteissueqty => $patron_maxonsiteissueqty,
-                    }
-                }
-            );
+    Koha::CirculationRules->set_rules(
+        {
+            categorycode => $categorycode eq '*' ? undef : $categorycode,
+            branchcode   => $branch eq '*'       ? undef : $branch,
+            rules        => {
+                max_holds                => $max_holds,
+                patron_maxissueqty       => $patron_maxissueqty,
+                patron_maxonsiteissueqty => $patron_maxonsiteissueqty,
+            }
         }
-    } elsif ( $categorycode eq "*" ) {
-        Koha::CirculationRules->set_rules(
-            {
-                categorycode => undef,
-                branchcode   => $branch,
-                rules        => {
-                    max_holds                => $max_holds,
-                    patron_maxissueqty       => $patron_maxissueqty,
-                    patron_maxonsiteissueqty => $patron_maxonsiteissueqty,
-                }
-            }
-        );
-    } else {
-        Koha::CirculationRules->set_rules(
-            {
-                categorycode => $categorycode,
-                branchcode   => $branch,
-                rules        => {
-                    max_holds                => $max_holds,
-                    patron_maxissueqty       => $patron_maxissueqty,
-                    patron_maxonsiteissueqty => $patron_maxonsiteissueqty,
-                }
-            }
-        );
-    }
+    );
 } elsif ( $op eq "cud-add-open-article-requests-limit" ) {
     my $categorycode                = $input->param('categorycode');
     my $open_article_requests_limit = strip_non_numeric( scalar $input->param('open_article_requests_limit') );
@@ -508,78 +398,22 @@ elsif ( $op eq 'cud-add' ) {
         if not defined $open_article_requests_limit    # There is a JS check for that
         || $open_article_requests_limit eq q{};
 
-    if ( $branch eq "*" ) {
-        if ( $categorycode eq "*" ) {
-            Koha::CirculationRules->set_rules(
-                {
-                    categorycode => undef,
-                    branchcode   => undef,
-                    rules        => { open_article_requests_limit => $open_article_requests_limit, }
-                }
-            );
-        } else {
-            Koha::CirculationRules->set_rules(
-                {
-                    categorycode => $categorycode,
-                    branchcode   => undef,
-                    rules        => { open_article_requests_limit => $open_article_requests_limit, }
-                }
-            );
+    Koha::CirculationRules->set_rules(
+        {
+            categorycode => $categorycode eq '*' ? undef : $categorycode,
+            branchcode   => $branch eq '*'       ? undef : $branch,
+            rules        => { open_article_requests_limit => $open_article_requests_limit, }
         }
-    } elsif ( $categorycode eq "*" ) {
-        Koha::CirculationRules->set_rules(
-            {
-                categorycode => undef,
-                branchcode   => $branch,
-                rules        => { open_article_requests_limit => $open_article_requests_limit, }
-            }
-        );
-    } else {
-        Koha::CirculationRules->set_rules(
-            {
-                categorycode => $categorycode,
-                branchcode   => $branch,
-                rules        => { open_article_requests_limit => $open_article_requests_limit, }
-            }
-        );
-    }
+    );
 } elsif ( $op eq 'cud-del-open-article-requests-limit' ) {
     my $categorycode = $input->param('categorycode');
-    if ( $branch eq "*" ) {
-        if ( $categorycode eq "*" ) {
-            Koha::CirculationRules->set_rules(
-                {
-                    branchcode   => undef,
-                    categorycode => undef,
-                    rules        => { open_article_requests_limit => undef, }
-                }
-            );
-        } else {
-            Koha::CirculationRules->set_rules(
-                {
-                    categorycode => $categorycode,
-                    branchcode   => undef,
-                    rules        => { open_article_requests_limit => undef, }
-                }
-            );
+    Koha::CirculationRules->set_rules(
+        {
+            categorycode => $categorycode eq '*' ? undef : $categorycode,
+            branchcode   => $branch eq '*'       ? undef : $branch,
+            rules        => { open_article_requests_limit => undef, }
         }
-    } elsif ( $categorycode eq "*" ) {
-        Koha::CirculationRules->set_rules(
-            {
-                branchcode   => $branch,
-                categorycode => undef,
-                rules        => { open_article_requests_limit => undef, }
-            }
-        );
-    } else {
-        Koha::CirculationRules->set_rules(
-            {
-                categorycode => $categorycode,
-                branchcode   => $branch,
-                rules        => { open_article_requests_limit => undef, }
-            }
-        );
-    }
+    );
 } elsif ( $op eq "cud-set-article-request-fee" ) {
 
     my $category = $input->param('article_request_fee_category');
@@ -616,65 +450,19 @@ elsif ( $op eq 'cud-add' ) {
     my $bookings_trail_period   = $input->param('bookings_trail_period');
     my $returnbranch            = $input->param('returnbranch');
 
-    if ( $branch eq "*" ) {
-        if ( $itemtype eq "*" ) {
-            Koha::CirculationRules->set_rules(
-                {
-                    itemtype   => undef,
-                    branchcode => undef,
-                    rules      => {
-                        holdallowed             => $holdallowed,
-                        hold_fulfillment_policy => $hold_fulfillment_policy,
-                        bookings_lead_period    => $bookings_lead_period,
-                        bookings_trail_period   => $bookings_trail_period,
-                        returnbranch            => $returnbranch,
-                    }
-                }
-            );
-        } else {
-            Koha::CirculationRules->set_rules(
-                {
-                    itemtype   => $itemtype,
-                    branchcode => undef,
-                    rules      => {
-                        holdallowed             => $holdallowed,
-                        hold_fulfillment_policy => $hold_fulfillment_policy,
-                        bookings_lead_period    => $bookings_lead_period,
-                        bookings_trail_period   => $bookings_trail_period,
-                        returnbranch            => $returnbranch,
-                    }
-                }
-            );
+    Koha::CirculationRules->set_rules(
+        {
+            itemtype   => $itemtype eq '*' ? undef : $itemtype,
+            branchcode => $branch eq '*'   ? undef : $branch,
+            rules      => {
+                holdallowed             => $holdallowed,
+                hold_fulfillment_policy => $hold_fulfillment_policy,
+                bookings_lead_period    => $bookings_lead_period,
+                bookings_trail_period   => $bookings_trail_period,
+                returnbranch            => $returnbranch,
+            }
         }
-    } elsif ( $itemtype eq "*" ) {
-        Koha::CirculationRules->set_rules(
-            {
-                itemtype   => undef,
-                branchcode => $branch,
-                rules      => {
-                    holdallowed             => $holdallowed,
-                    hold_fulfillment_policy => $hold_fulfillment_policy,
-                    bookings_lead_period    => $bookings_lead_period,
-                    bookings_trail_period   => $bookings_trail_period,
-                    returnbranch            => $returnbranch,
-                }
-            }
-        );
-    } else {
-        Koha::CirculationRules->set_rules(
-            {
-                itemtype   => $itemtype,
-                branchcode => $branch,
-                rules      => {
-                    holdallowed             => $holdallowed,
-                    hold_fulfillment_policy => $hold_fulfillment_policy,
-                    bookings_lead_period    => $bookings_lead_period,
-                    bookings_trail_period   => $bookings_trail_period,
-                    returnbranch            => $returnbranch,
-                }
-            }
-        );
-    }
+    );
 } elsif ( $op eq 'cud-mod-refund-lost-item-fee-rule' ) {
 
     my $lostreturn = $input->param('lostreturn');


### PR DESCRIPTION
This patch simplifies the circulation rules script by replacing repetitive conditional blocks with ternary operators for converting '*' (default/all) values to undef.

The following operations were simplified:
- cud-delete-branch-item: 4 code paths reduced to 1
- cud-set-branch-defaults: 2 code paths reduced to 1
- cud-add-branch-cat: 4 code paths reduced to 1
- cud-add-open-article-requests-limit: 4 code paths reduced to 1
- cud-del-open-article-requests-limit: 4 code paths reduced to 1
- cud-add-branch-item: 4 code paths reduced to 1

The cud-delete-branch-cat operation was NOT simplified because it contains additional business logic (setting itemtype rules only when deleting the default categorycode), which is not simply a matter of converting '*' to undef.

Test plan:
1. Go to Administration > Circulation and fine rules
2. Test adding/deleting branch-item rules for various combinations:
   - All libraries / All item types
   - All libraries / Specific item type
   - Specific library / All item types
   - Specific library / Specific item type
3. Verify rules are correctly added and deleted in each case
4. Test the same combinations for patron category rules

https://claude.ai/code/session_01CBhrEcy13tZYSFtYCpAzEa